### PR TITLE
add option to set a page primary

### DIFF
--- a/pretix_pages/models.py
+++ b/pretix_pages/models.py
@@ -26,6 +26,8 @@ class Page(LoggedModel):
     require_confirmation = models.BooleanField(default=False,
                                                verbose_name=_('Require the user to acknowledge this page before an '
                                                               'order is created (e.g. for terms of service).'))
+    is_primary = models.BooleanField(default=False, verbose_name=_('Show this page on the frontpage directly, '
+                                                                   'ignoring other pages.'))
 
     class Meta:
         ordering = ['position', 'title']

--- a/pretix_pages/signals.py
+++ b/pretix_pages/signals.py
@@ -65,6 +65,13 @@ def footer_link_pages(sender, request=None, **kwargs):
 
 @receiver(signal=front_page_bottom, dispatch_uid="pages_frontpage_linls")
 def pretixpresale_front_page_bottom(sender, **kwargs):
+    primary_pages = list(Page.objects.filter(event=sender, is_primary=True))
+    if primary_pages:
+        template = get_template('pretix_pages/primary_page.html')
+        return template.render({
+            'event': sender,
+            'page': primary_pages[0]
+        })
     pages = list(Page.objects.filter(event=sender, link_on_frontpage=True))
     if pages:
         template = get_template('pretix_pages/front_page.html')

--- a/pretix_pages/templates/pretix_pages/form.html
+++ b/pretix_pages/templates/pretix_pages/form.html
@@ -17,6 +17,7 @@
                     {% bootstrap_field form.link_on_frontpage layout="horizontal" %}
                     {% bootstrap_field form.link_in_footer layout="horizontal" %}
                     {% bootstrap_field form.require_confirmation layout="horizontal" %}
+                    {% bootstrap_field form.is_primary layout="horizontal" %}
                 </fieldset>
                 <fieldset id="content">
                     <legend>{% trans "Page content" %}</legend>

--- a/pretix_pages/templates/pretix_pages/primary_page.html
+++ b/pretix_pages/templates/pretix_pages/primary_page.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block content %}
+
+    <h2>{{ page.title }}</h2>
+    <div class="ql-content">
+        {{ page.text|safe }}
+    </div>
+
+{% endblock %}

--- a/pretix_pages/views.py
+++ b/pretix_pages/views.py
@@ -82,7 +82,7 @@ class PageForm(I18nModelForm):
     class Meta:
         model = Page
         fields = (
-            'title', 'slug', 'text', 'link_in_footer', 'link_on_frontpage', 'require_confirmation'
+            'title', 'slug', 'text', 'link_in_footer', 'link_on_frontpage', 'require_confirmation', 'is_primary'
         )
 
     def clean_slug(self):


### PR DESCRIPTION
Hi, I add an option to make a page primary, which means that page would show up on the front page directly(ignoring other pages and the original "More information" section), it looks like this
![](http://i.imgur.com/wxem7IM.png)
Currently there's no limitations on how many pages can be set as primary, but only one page can be displayed(others would be ignored), how do you think about it?