### PR TITLE
Add image support

### DIFF
--- a/pretix_pages/static/pretix_pages/editor.js
+++ b/pretix_pages/static/pretix_pages/editor.js
@@ -36,13 +36,14 @@ $(function () {
             theme: 'snow',
             formats: [
                 'bold', 'italic', 'link', 'strike', 'code', 'underline', 'script',
-                'list', 'align', 'code-block', 'header'
+                'list', 'align', 'code-block', 'header', 'image'
             ],
             modules: {
                 toolbar: [
                     [{'header': [3, 4, 5, false]}],
                     ['bold', 'italic', 'underline', 'strike'],
                     ['link'],
+                    ['image'],
                     [{'align': []}],
                     [{'list': 'ordered'}, {'list': 'bullet'}],
                     [{'script': 'sub'}, {'script': 'super'}],

--- a/pretix_pages/static/pretix_pages/quill-edit.css
+++ b/pretix_pages/static/pretix_pages/quill-edit.css
@@ -4,3 +4,8 @@
 .ql-container {
     font-size: 14px;
 }
+.ql-content img {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+}

--- a/pretix_pages/static/pretix_pages/quill-show.css
+++ b/pretix_pages/static/pretix_pages/quill-show.css
@@ -7,6 +7,11 @@
 .ql-align-right {
     text-align: right;
 }
+.ql-content img {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+}
 .ql-content p,
 .ql-content ol,
 .ql-content ul,

--- a/pretix_pages/views.py
+++ b/pretix_pages/views.py
@@ -248,8 +248,10 @@ class ShowPageView(TemplateView):
         attributes['a'] = ['href', 'title', 'target']
         attributes['p'] = ['class']
         attributes['li'] = ['class']
+        attributes['img'] = ['src']
 
         ctx['content'] = bleach.clean(str(page.text), tags=bleach.ALLOWED_TAGS + [
+            'img',
             'p',
             'br',
             's',
@@ -260,5 +262,5 @@ class ShowPageView(TemplateView):
             'h4',
             'h5',
             'h6'
-        ], attributes=attributes)
+        ], attributes=attributes, protocols=bleach.ALLOWED_PROTOCOLS + ['data'])
         return ctx

--- a/pretix_pages/views.py
+++ b/pretix_pages/views.py
@@ -1,19 +1,23 @@
+from urllib.request import urlopen
+
 import bleach
+import lxml.html
 from django import forms
 from django.contrib import messages
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import Max
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.decorators import method_decorator
+from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView, DeleteView, ListView, TemplateView, UpdateView,
 )
 from pretix.base.forms import I18nModelForm
 from pretix.control.permissions import EventPermissionRequiredMixin, event_permission_required
-from pretix.presale.utils import event_view
 
 from .models import Page
 
@@ -94,6 +98,35 @@ class PageForm(I18nModelForm):
                 code='duplicate_slug',
             )
         return slug
+
+    mimes = {
+        'image/gif': 'gif',
+        'image/jpeg': 'jpg',
+        'image/png': 'png',
+        'image/webp': 'webp',
+    }
+
+    def clean_text(self):
+        t = self.cleaned_data['text']
+        for locale, html in t.data.items():
+            etrees = lxml.html.fragments_fromstring(html)
+            t.data[locale] = ""
+            for etree in etrees:
+                # Find all data:-based image URLs, store them to CDN and replace the image node
+                for image in etree.xpath('//img'):
+                    original_image_src = image.attrib['src']
+                    if original_image_src.startswith('data:'):
+                        ftype = original_image_src.split(';')[0][5:]
+                        if ftype in self.mimes:
+                            with urlopen(original_image_src) as response:
+                                cfile = ContentFile(response.read())
+                                nonce = get_random_string(length=32)
+                                name = 'pub/{}/pages/img/{}.{}'.format(self.event.organizer.slug, nonce, self.mimes[ftype])
+                                stored_name = default_storage.save(name, cfile)
+                                stored_url = default_storage.url(stored_name)
+                                image.attrib['src'] = stored_url
+                t.data[locale] += lxml.html.tostring(etree).decode()
+        return t
 
 
 class PageEditForm(PageForm):


### PR DESCRIPTION
To decide: Do we have a good way to clean images off the CDN once they're no longer in use? Might be hard to do since they aren't cloned when pages are cloned, so we might just keep it this way for now.