### PR TITLE
Remove wrong space for not breaking cache

### DIFF
--- a/pretix_pages/signals.py
+++ b/pretix_pages/signals.py
@@ -64,7 +64,7 @@ def footer_link_pages(sender, request=None, **kwargs):
                 })
             } for p in Page.objects.filter(event=sender, link_in_footer=True)
         ]
-        sender.cache.set('pages_footer_links_ ' + get_language(), cached)
+        sender.cache.set('pages_footer_links_' + get_language(), cached)
 
     return cached
 


### PR DESCRIPTION
Solves:
jango.core.cache.backends.base.InvalidCacheKey: Cache key contains characters that will cause errors if used with memcached: ':1:Event:20:1667154168:pages_footer_links_ de-de'