### PR TITLE
Enable empty lines by forcing empty p elements to be at least one line high

### DIFF
--- a/pretix_pages/static/pretix_pages/quill-show.css
+++ b/pretix_pages/static/pretix_pages/quill-show.css
@@ -27,6 +27,20 @@
     padding: 0;
     counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
 }
+.ql-content p:before,
+.ql-content ol:before,
+.ql-content ul:before,
+.ql-content pre:before,
+.ql-content blockquote:before,
+.ql-content h1:before,
+.ql-content h2:before,
+.ql-content h3:before,
+.ql-content h4:before,
+.ql-content h5:before,
+.ql-content h6:before {
+    /* ensure emtpy elements take space for at least one line with a zero-width-space */
+    content: '\200B';
+}
 .ql-content ol,
 .ql-content ul {
     padding-left: 1.5em;

--- a/pretix_pages/static/pretix_pages/quill-show.css
+++ b/pretix_pages/static/pretix_pages/quill-show.css
@@ -27,18 +27,8 @@
     padding: 0;
     counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
 }
-.ql-content p:before,
-.ql-content ol:before,
-.ql-content ul:before,
-.ql-content pre:before,
-.ql-content blockquote:before,
-.ql-content h1:before,
-.ql-content h2:before,
-.ql-content h3:before,
-.ql-content h4:before,
-.ql-content h5:before,
-.ql-content h6:before {
-    /* ensure emtpy elements take space for at least one line with a zero-width-space */
+.ql-content p:before {
+    /* ensure emtpy lines take space for at least one line with a zero-width-space */
     content: '\200B';
 }
 .ql-content ol,


### PR DESCRIPTION
The update to quilljs 2.0.2 forced us to use getSemanticHTML, which converted multiple empty lines to empty `<p>` elements.